### PR TITLE
Introduced an entrypoint script to autotune the number of worker proc…

### DIFF
--- a/Dockerfile-alpine.template
+++ b/Dockerfile-alpine.template
@@ -105,6 +105,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/Dockerfile-debian.template
+++ b/Dockerfile-debian.template
@@ -96,6 +96,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/entrypoint/30-tune-worker-processes.sh
+++ b/entrypoint/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/alpine-perl/30-tune-worker-processes.sh
+++ b/mainline/alpine-perl/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/alpine-perl/Dockerfile
+++ b/mainline/alpine-perl/Dockerfile
@@ -116,6 +116,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/mainline/alpine/30-tune-worker-processes.sh
+++ b/mainline/alpine/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/alpine/Dockerfile
+++ b/mainline/alpine/Dockerfile
@@ -115,6 +115,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/mainline/debian-perl/30-tune-worker-processes.sh
+++ b/mainline/debian-perl/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/debian-perl/Dockerfile
+++ b/mainline/debian-perl/Dockerfile
@@ -107,6 +107,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/mainline/debian/30-tune-worker-processes.sh
+++ b/mainline/debian/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/mainline/debian/Dockerfile
+++ b/mainline/debian/Dockerfile
@@ -106,6 +106,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/stable/alpine-perl/30-tune-worker-processes.sh
+++ b/stable/alpine-perl/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/alpine-perl/Dockerfile
+++ b/stable/alpine-perl/Dockerfile
@@ -116,6 +116,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/stable/alpine/30-tune-worker-processes.sh
+++ b/stable/alpine/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/alpine/Dockerfile
+++ b/stable/alpine/Dockerfile
@@ -115,6 +115,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/stable/debian-perl/30-tune-worker-processes.sh
+++ b/stable/debian-perl/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/debian-perl/Dockerfile
+++ b/stable/debian-perl/Dockerfile
@@ -107,6 +107,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80

--- a/stable/debian/30-tune-worker-processes.sh
+++ b/stable/debian/30-tune-worker-processes.sh
@@ -1,0 +1,127 @@
+#!/bin/sh
+# vim:sw=2:ts=2:sts=2:et
+
+set -eu
+
+LC_ALL=C
+ME=$( basename "$0" )
+PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+[ "${NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE:-}" ] || exit 0
+
+touch /etc/nginx/nginx.conf 2>/dev/null || { echo >&2 "$ME: error: can not modify /etc/nginx/nginx.conf (read-only file system?)"; exit 0; }
+
+ceildiv() {
+    num=$1
+    div=$2
+    echo $(( (num + div - 1) / div ))
+}
+
+get_cpuset() {
+  cpusetroot=$1
+  ncpu=0
+  [ -f "$cpusetroot/cpuset.effective_cpus" ] || return
+  for token in $( tr ',' ' ' < "$cpusetroot/cpuset.effective_cpus" ); do
+    case "$token" in
+      *-*)
+        count=$( seq $(echo "$token" | tr '-' ' ') | wc -l )
+        ncpu=$(( ncpu+count ))
+        ;;
+      *)
+        ncpu=$(( ncpu+1 ))
+        ;;
+    esac
+  done
+  echo "$ncpu"
+}
+
+get_quota() {
+  cpuroot=$1
+  ncpu=0
+  [ -f "$cpuroot/cpu.cfs_quota_us" ] || return
+  [ -f "$cpuroot/cpu.cfs_period_us" ] || return
+  cfs_quota=$( cat "$cpuroot/cpu.cfs_quota_us" )
+  cfs_period=$( cat "$cpuroot/cpu.cfs_period_us" )
+  [ "$cfs_quota" = "-1" ] && return
+  [ "$cfs_period" = "0" ] && return
+  ncpu=$( ceildiv "$cfs_quota" "$cfs_period" )
+  [ "$ncpu" -gt 0 ] || return
+  echo "$ncpu"
+}
+
+get_cgroup_path() {
+  needle=$1
+  foundroot=
+  mountpoint=
+
+  [ -r "/proc/self/mountinfo" ] || return
+  [ -r "/proc/self/cgroup" ] || return
+
+  while IFS= read -r line; do
+    case "$needle" in
+      "cpuset")
+        case "$line" in
+          *cpuset*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$line" in
+          *cpuset*)
+            ;;
+          *cpu,cpuacct*|*cpuacct,cpu|*cpuacct*|*cpu*)
+            found=$( echo "$line" | cut -d ' ' -f 4,5 )
+            ;;
+        esac
+    esac
+  done << __EOF__
+$( grep -F -- '- cgroup ' /proc/self/mountinfo )
+__EOF__
+
+  while IFS= read -r line; do
+    controller=$( echo "$line" | cut -d: -f 2 )
+    case "$needle" in
+      "cpuset")
+        case "$controller" in
+          cpuset)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+      "cpu")
+        case "$controller" in
+          cpu,cpuacct|cpuacct,cpu|cpuacct|cpu)
+            mountpoint=$( echo "$line" | cut -d: -f 3 )
+            ;;
+        esac
+        ;;
+    esac
+done << __EOF__
+$( grep -F -- 'cpu' /proc/self/cgroup )
+__EOF__
+
+  case "${found%% *}" in
+    "/")
+      foundroot="${found##* }$mountpoint"
+      ;;
+    "$mountpoint")
+      foundroot="${found##* }"
+      ;;
+  esac
+  echo "$foundroot"
+}
+
+ncpu_online=$( getconf _NPROCESSORS_ONLN )
+
+cpuset=$( get_cgroup_path "cpuset" )
+[ "$cpuset" ] && ncpu_cpuset=$( get_cpuset "$cpuset" )
+[ "$ncpu_cpuset" ] || ncpu_cpuset=$ncpu_online
+
+cpu=$( get_cgroup_path "cpu" )
+[ "$cpu" ] && ncpu_quota=$( get_quota "$cpu" )
+[ "$ncpu_quota" ] || ncpu_quota=$ncpu_online
+
+ncpu=$( printf "%s\n%s\n%s\n" "$ncpu_online" "$ncpu_quota" "$ncpu_cpuset" | sort -n | head -n 1 )
+
+sed -i.bak -r 's/^(worker_processes)(.*)$/# Commented out by '"$ME"' on '"$(date)"'\n#\1\2\n\1 '"$ncpu"';/' /etc/nginx/nginx.conf

--- a/stable/debian/Dockerfile
+++ b/stable/debian/Dockerfile
@@ -106,6 +106,7 @@ RUN set -x \
 COPY docker-entrypoint.sh /
 COPY 10-listen-on-ipv6-by-default.sh /docker-entrypoint.d
 COPY 20-envsubst-on-templates.sh /docker-entrypoint.d
+COPY 30-tune-worker-processes.sh /docker-entrypoint.d
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
 EXPOSE 80


### PR DESCRIPTION
…esses

The script is a no-op bye default, you would need to enable its logic by setting an NGINX_ENTRYPOINT_WORKER_PROCESSES_AUTOTUNE variable to any value.

The script then tries to get the following values:

 - getconf _NPROCESSORS_ONLN
 - the amount of cpus from cpuset cgroup
 - the quotas from cpu/cpuacct cgroup

The lowest of all three is then applied to nginx.conf.